### PR TITLE
Fix currency symbol display in payment tracker

### DIFF
--- a/collectify.html
+++ b/collectify.html
@@ -5132,7 +5132,7 @@
               ${extraLine}
             </div>
             <div class="tracker-amount paid">
-              ���${entry.totalPaid.toFixed(2)}
+              ₱${entry.totalPaid.toFixed(2)}
             </div>
           </div>`;
           })


### PR DESCRIPTION
## Purpose
Fix the display of question mark emojis in the custom payment section by replacing corrupted currency symbols with proper peso (₱) symbols.

## Code changes
- Replaced corrupted currency symbol characters (`���`) with proper peso symbol (`₱`) in the payment tracker amount display
- Updated the `totalPaid` amount formatting in `collectify.html` to show correct currency symbol

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6f908d77452b404395f136c9b2f7a705/echo-garden)

👀 [Preview Link](https://6f908d77452b404395f136c9b2f7a705-echo-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6f908d77452b404395f136c9b2f7a705</projectId>-->
<!--<branchName>echo-garden</branchName>-->