### PR TITLE
Fix tutorial mode to open client selectors in all tabs

### DIFF
--- a/collectify.html
+++ b/collectify.html
@@ -6009,6 +6009,7 @@
         updateAbsenceHistory();
         updateSettingsInfo();
         closeAllModals();
+        closeAllSheets();
         closeTutorialLayer();
       }
 
@@ -6024,6 +6025,14 @@
           const el = document.getElementById(id);
           if (el) el.classList.remove("active");
         });
+      }
+
+      function closeAllSheets() {
+        try {
+          document.querySelectorAll('.ios-sheet-overlay.show').forEach((el)=>el.classList.remove('show'));
+          document.querySelectorAll('.ios-sheet.show').forEach((el)=>el.classList.remove('show'));
+          document.querySelectorAll('.ios-select-button[aria-expanded="true"]').forEach((b)=>b.setAttribute('aria-expanded','false'));
+        } catch (e) {}
       }
 
       function buildTutorialSteps() {
@@ -6075,11 +6084,13 @@
           },
           {
             text: "Pick a client to record a payment.",
-            selector: "#notebookClient",
+            selector: "#notebookClientPickerBtn",
             padding: 6,
             onBefore: () => {
               closeSidebar();
               switchTab("notebook");
+              const btn = document.getElementById("notebookClientPickerBtn");
+              if (btn) btn.click();
             },
           },
           {
@@ -6127,11 +6138,13 @@
           },
           {
             text: "Pick a client for office payment here.",
-            selector: "#officeClient",
+            selector: "#officeClientPickerBtn",
             padding: 6,
             onBefore: () => {
               closeSidebar();
               switchTab("office");
+              const btn = document.getElementById("officeClientPickerBtn");
+              if (btn) btn.click();
             },
           },
           {
@@ -6156,11 +6169,13 @@
           },
           {
             text: "Pick a client for GCash payment here.",
-            selector: "#gcashClient",
+            selector: "#gcashClientPickerBtn",
             padding: 6,
             onBefore: () => {
               closeSidebar();
               switchTab("gcash");
+              const btn = document.getElementById("gcashClientPickerBtn");
+              if (btn) btn.click();
             },
           },
           {
@@ -6184,11 +6199,13 @@
           },
           {
             text: "Pick a client for Adv entry here.",
-            selector: "#advClient",
+            selector: "#advClientPickerBtn",
             padding: 6,
             onBefore: () => {
               closeSidebar();
               switchTab("adv");
+              const btn = document.getElementById("advClientPickerBtn");
+              if (btn) btn.click();
             },
           },
           {
@@ -6212,11 +6229,13 @@
           },
           {
             text: "Pick a client to mark absent.",
-            selector: "#absentClient",
+            selector: "#absentClientPickerBtn",
             padding: 6,
             onBefore: () => {
               closeSidebar();
               switchTab("absent");
+              const btn = document.getElementById("absentClientPickerBtn");
+              if (btn) btn.click();
             },
           },
           {
@@ -6311,6 +6330,7 @@
 
       function onTutorialClick() {
         if (!tutorial.active) return;
+        closeAllSheets();
         const step = tutorial.steps[tutorial.index];
         if (step && step.openTab) {
           closeSidebar();


### PR DESCRIPTION
## Purpose
Fix tutorial mode functionality where tutorial steps were only pointing to static client display elements instead of interactive client selector buttons. The user needed the tutorial to properly open client selector dropdowns in all tabs (notebook, office, gcash, adv, absent) to show the actual client lists, rather than just highlighting non-interactive elements.

## Code changes
- **Added `closeAllSheets()` function**: Closes iOS-style sheet overlays and resets aria-expanded attributes to ensure clean state transitions
- **Updated tutorial step selectors**: Changed from static client display elements (`#notebookClient`, `#officeClient`, etc.) to interactive picker buttons (`#notebookClientPickerBtn`, `#officeClientPickerBtn`, etc.)
- **Enhanced `onBefore` callbacks**: Added button click functionality to automatically open client selector dropdowns when tutorial steps are triggered
- **Improved tutorial cleanup**: Added `closeAllSheets()` calls in `resetTutorial()` and `onTutorialClick()` to prevent UI conflicts during tutorial navigation

All changes maintained in single vanilla HTML file as requested.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 7`

🔗 [Edit in Builder.io](https://builder.io/app/projects/18bddb6f1049463481f98ee6dc58f047/vortex-haven)

👀 [Preview Link](https://18bddb6f1049463481f98ee6dc58f047-vortex-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>18bddb6f1049463481f98ee6dc58f047</projectId>-->
<!--<branchName>vortex-haven</branchName>-->