### PR TITLE
Remove hamburger menu rounded corners for cleaner look

### DIFF
--- a/collectify.html
+++ b/collectify.html
@@ -201,6 +201,19 @@
         transition: all 0.1s ease;
       }
 
+      .icon-btn.menu-btn {
+        background: transparent;
+        border: none;
+        border-radius: 0;
+        box-shadow: none;
+      }
+      .icon-btn.menu-btn:hover,
+      .icon-btn.menu-btn:active {
+        background: transparent;
+        box-shadow: none;
+        transform: none;
+      }
+
       .theme-toggle.active {
         background: var(--ios-blue);
         color: var(--ios-secondary-grouped-background);
@@ -2009,7 +2022,7 @@
               d="M3 6h18M3 12h18M3 18h18"
               stroke="currentColor"
               stroke-width="2"
-              stroke-linecap="round"
+              stroke-linecap="square"
               fill="none"
             ></path>
           </svg>


### PR DESCRIPTION
## Purpose
The user requested to remove the rounded corners from the hamburger menu icon to create a seamless and clean appearance with the header. The goal was to make the hamburger icon appear as simple horizontal lines without any visual styling that would make it stand out from the header design.

## Code changes
- Added CSS rules for `.icon-btn.menu-btn` to override default button styling:
  - Set `background: transparent` and `border: none`
  - Removed `border-radius` and `box-shadow`
  - Disabled hover/active state transformations and shadows
- Changed hamburger icon SVG `stroke-linecap` from "round" to "square" to create sharp, clean line endings instead of rounded caps

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 19`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ddc27412aea345568b2b622a01947888/swoosh-sanctuary)

👀 [Preview Link](https://ddc27412aea345568b2b622a01947888-swoosh-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddc27412aea345568b2b622a01947888</projectId>-->
<!--<branchName>swoosh-sanctuary</branchName>-->