### PR TITLE
Add Summary tab tutorial steps to tutorial mode

### DIFF
--- a/collectify.html
+++ b/collectify.html
@@ -7791,6 +7791,15 @@
             openTab: "overdue",
           },
           {
+            text: "Here you can Full Pay, set a Repayment Plan, or record a plan payment.",
+            selector: "#overdueList",
+            padding: 8,
+            onBefore: () => {
+              closeSidebar();
+              switchTab("overdue");
+            },
+          },
+          {
             text: "Summary tab: view totals across sources for a chosen date.",
             selector: '.sidebar .tab[data-tab="summary"]',
             padding: 6,
@@ -7811,15 +7820,6 @@
             text: "These tiles show Notebook, GCash, Adv, Overpay, and Absent totals.",
             selector: "#summary .stats-grid",
             padding: 8,
-          },
-          {
-            text: "Here you can Full Pay, set a Repayment Plan, or record a plan payment.",
-            selector: "#overdueList",
-            padding: 8,
-            onBefore: () => {
-              closeSidebar();
-              switchTab("overdue");
-            },
           },
           {
             text: "Notebook: record daily payments.",
@@ -8030,33 +8030,6 @@
             padding: 8,
           },
 
-          {
-            text: "Summary: view totals and detailed lists for a selected date.",
-            selector: '.sidebar .tab[data-tab="summary"]',
-            padding: 6,
-            needsSidebar: true,
-            wait: 450,
-            openTab: "summary",
-          },
-          {
-            text: "Pick a date to populate the summary totals and lists.",
-            selector: "#summaryDate",
-            padding: 8,
-            onBefore: () => {
-              closeSidebar();
-              switchTab("summary");
-            },
-          },
-          {
-            text: "Quick totals for Notebook, GCash, Adv, Overpayment, and Absent appear here.",
-            selector: "#summary .stats-grid",
-            padding: 10,
-          },
-          {
-            text: "See per-category details. This shows Notebook entries for the day.",
-            selector: "#summaryNotebookList",
-            padding: 8,
-          },
           {
             text: "Settings: configure app preferences, manage data, and customize the interface.",
             selector: '.sidebar .tab[data-tab="settings"]',

--- a/collectify.html
+++ b/collectify.html
@@ -8009,6 +8009,33 @@
           },
 
           {
+            text: "Summary: view totals and detailed lists for a selected date.",
+            selector: '.sidebar .tab[data-tab="summary"]',
+            padding: 6,
+            needsSidebar: true,
+            wait: 450,
+            openTab: "summary",
+          },
+          {
+            text: "Pick a date to populate the summary totals and lists.",
+            selector: "#summaryDate",
+            padding: 8,
+            onBefore: () => {
+              closeSidebar();
+              switchTab("summary");
+            },
+          },
+          {
+            text: "Quick totals for Notebook, GCash, Adv, Overpayment, and Absent appear here.",
+            selector: "#summary .stats-grid",
+            padding: 10,
+          },
+          {
+            text: "See per-category details. This shows Notebook entries for the day.",
+            selector: "#summaryNotebookList",
+            padding: 8,
+          },
+          {
             text: "Settings: configure app preferences, manage data, and customize the interface.",
             selector: '.sidebar .tab[data-tab="settings"]',
             padding: 6,

--- a/collectify.html
+++ b/collectify.html
@@ -7791,6 +7791,28 @@
             openTab: "overdue",
           },
           {
+            text: "Summary tab: view totals across sources for a chosen date.",
+            selector: '.sidebar .tab[data-tab="summary"]',
+            padding: 6,
+            needsSidebar: true,
+            wait: 450,
+            openTab: "summary",
+          },
+          {
+            text: "Pick a date to update the Summary.",
+            selector: "#summaryDate",
+            padding: 6,
+            onBefore: () => {
+              closeSidebar();
+              switchTab("summary");
+            },
+          },
+          {
+            text: "These tiles show Notebook, GCash, Adv, Overpay, and Absent totals.",
+            selector: "#summary .stats-grid",
+            padding: 8,
+          },
+          {
             text: "Here you can Full Pay, set a Repayment Plan, or record a plan payment.",
             selector: "#overdueList",
             padding: 8,

--- a/collectify.html
+++ b/collectify.html
@@ -398,16 +398,6 @@
         border-top: 0.5px solid var(--ios-opaque-separator);
       }
 
-      .sidebar-section-title {
-        padding: 10px 16px;
-        font-size: 12px;
-        font-weight: 700;
-        color: var(--ios-secondary-label);
-        background: var(--ios-secondary-grouped-background);
-        border-bottom: 0.5px solid var(--ios-opaque-separator);
-        letter-spacing: 0.3px;
-        text-transform: uppercase;
-      }
 
       .sidebar .tab.active {
         background: var(--ios-gray5);
@@ -2132,28 +2122,29 @@
           </button>
         </div>
         <div class="settings-group">
-          <div class="sidebar-section-title">Overview</div>
           <button class="tab" data-tab="dashboard" onclick="closeSidebar()">
             <span>Dashboard</span>
+          </button>
+          <button class="tab" data-tab="overdue" onclick="closeSidebar()">
+            <span>Overdue</span>
+          </button>
+          <button class="tab" data-tab="notebook" onclick="closeSidebar()">
+            <span>Notebook</span>
+          </button>
+          <button class="tab" data-tab="daily-tracker" onclick="closeSidebar()">
+            <span>Daily Tracker</span>
           </button>
           <button class="tab" data-tab="summary" onclick="closeSidebar()">
             <span>Summary</span>
           </button>
         </div>
         <div class="settings-group">
-          <div class="sidebar-section-title">Collections</div>
-          <button class="tab" data-tab="notebook" onclick="closeSidebar()">
-            <span>Notebook</span>
-          </button>
           <button class="tab" data-tab="office" onclick="closeSidebar()">
             <span>Office</span>
           </button>
           <button class="tab" data-tab="gcash" onclick="closeSidebar()">
             <span>GCash</span>
           </button>
-        </div>
-        <div class="settings-group">
-          <div class="sidebar-section-title">Adjustments</div>
           <button class="tab" data-tab="adv" onclick="closeSidebar()">
             <span>Adv</span>
           </button>
@@ -2162,19 +2153,9 @@
           </button>
         </div>
         <div class="settings-group">
-          <div class="sidebar-section-title">Monitoring</div>
-          <button class="tab" data-tab="daily-tracker" onclick="closeSidebar()">
-            <span>Daily Tracker</span>
-          </button>
-          <button class="tab" data-tab="overdue" onclick="closeSidebar()">
-            <span>Overdue</span>
-          </button>
           <button class="tab" data-tab="absent" onclick="closeSidebar()">
             <span>Absent</span>
           </button>
-        </div>
-        <div class="settings-group">
-          <div class="sidebar-section-title">Settings & Help</div>
           <button class="tab" data-tab="settings" onclick="closeSidebar()">
             <span>Settings</span>
           </button>

--- a/collectify.html
+++ b/collectify.html
@@ -398,6 +398,17 @@
         border-top: 0.5px solid var(--ios-opaque-separator);
       }
 
+      .sidebar-section-title {
+        padding: 10px 16px;
+        font-size: 12px;
+        font-weight: 700;
+        color: var(--ios-secondary-label);
+        background: var(--ios-secondary-grouped-background);
+        border-bottom: 0.5px solid var(--ios-opaque-separator);
+        letter-spacing: 0.3px;
+        text-transform: uppercase;
+      }
+
       .sidebar .tab.active {
         background: var(--ios-gray5);
       }
@@ -2121,29 +2132,28 @@
           </button>
         </div>
         <div class="settings-group">
+          <div class="sidebar-section-title">Overview</div>
           <button class="tab" data-tab="dashboard" onclick="closeSidebar()">
             <span>Dashboard</span>
-          </button>
-          <button class="tab" data-tab="overdue" onclick="closeSidebar()">
-            <span>Overdue</span>
-          </button>
-          <button class="tab" data-tab="notebook" onclick="closeSidebar()">
-            <span>Notebook</span>
-          </button>
-          <button class="tab" data-tab="daily-tracker" onclick="closeSidebar()">
-            <span>Daily Tracker</span>
           </button>
           <button class="tab" data-tab="summary" onclick="closeSidebar()">
             <span>Summary</span>
           </button>
         </div>
         <div class="settings-group">
+          <div class="sidebar-section-title">Collections</div>
+          <button class="tab" data-tab="notebook" onclick="closeSidebar()">
+            <span>Notebook</span>
+          </button>
           <button class="tab" data-tab="office" onclick="closeSidebar()">
             <span>Office</span>
           </button>
           <button class="tab" data-tab="gcash" onclick="closeSidebar()">
             <span>GCash</span>
           </button>
+        </div>
+        <div class="settings-group">
+          <div class="sidebar-section-title">Adjustments</div>
           <button class="tab" data-tab="adv" onclick="closeSidebar()">
             <span>Adv</span>
           </button>
@@ -2152,9 +2162,19 @@
           </button>
         </div>
         <div class="settings-group">
+          <div class="sidebar-section-title">Monitoring</div>
+          <button class="tab" data-tab="daily-tracker" onclick="closeSidebar()">
+            <span>Daily Tracker</span>
+          </button>
+          <button class="tab" data-tab="overdue" onclick="closeSidebar()">
+            <span>Overdue</span>
+          </button>
           <button class="tab" data-tab="absent" onclick="closeSidebar()">
             <span>Absent</span>
           </button>
+        </div>
+        <div class="settings-group">
+          <div class="sidebar-section-title">Settings & Help</div>
           <button class="tab" data-tab="settings" onclick="closeSidebar()">
             <span>Settings</span>
           </button>


### PR DESCRIPTION
## Purpose
The user wanted to improve the tutorial mode to include comprehensive coverage of the Summary tab functionality. They noticed that the tutorial mode was not teaching users about the Summary tab in the sidebar and was skipping directly to the overdue tab, missing important functionality that users should learn about.

## Code changes
- Added three new tutorial steps for the Summary tab functionality
- Added step to introduce the Summary tab in the sidebar with explanation of viewing totals across sources
- Added step to teach users about the date picker functionality for updating the Summary
- Added step to explain the stats grid tiles showing Notebook, GCash, Adv, Overpay, and Absent totals
- Positioned the Summary tutorial steps before the existing Notebook tutorial step to maintain logical flow

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 26`

🔗 [Edit in Builder.io](https://builder.io/app/projects/bd4ca18e994a4c368ba06393a7733131/quantum-hub)

👀 [Preview Link](https://bd4ca18e994a4c368ba06393a7733131-quantum-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>bd4ca18e994a4c368ba06393a7733131</projectId>-->
<!--<branchName>quantum-hub</branchName>-->