### PR TITLE
Update "Not Paid Today" text to "Not Paid"

### DIFF
--- a/collectify.html
+++ b/collectify.html
@@ -1438,6 +1438,8 @@
         align-items: center;
         gap: 6px;
         white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
       .tracker-title-paid { color: var(--ios-green); }
       .tracker-title-unpaid { color: var(--ios-red); }

--- a/collectify.html
+++ b/collectify.html
@@ -1431,6 +1431,17 @@
         transform: translateY(0) scale(0.98);
       }
 
+      /* Tracker section titles */
+      .tracker-section-title {
+        margin-bottom: 15px;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        white-space: nowrap;
+      }
+      .tracker-title-paid { color: var(--ios-green); }
+      .tracker-title-unpaid { color: var(--ios-red); }
+
       /* Responsive Design for All Screen Sizes and Orientations */
       @media (max-width: 768px) {
         .container {
@@ -2477,7 +2488,7 @@
               "
             >
               <div>
-                <h3 style="color: var(--ios-green); margin-bottom: 15px">
+                <h3 class="tracker-section-title tracker-title-paid">
                   <svg
                     class="icon-inline"
                     viewBox="0 0 24 24"
@@ -2513,7 +2524,7 @@
               </div>
 
               <div>
-                <h3 style="color: var(--ios-red); margin-bottom: 15px">
+                <h3 class="tracker-section-title tracker-title-unpaid">
                   <svg
                     class="icon-inline"
                     viewBox="0 0 24 24"

--- a/collectify.html
+++ b/collectify.html
@@ -2451,7 +2451,7 @@
                 "
               >
                 <h3 id="notPaidToday">0</h3>
-                <p>Not Paid Today</p>
+                <p>Not Paid</p>
               </div>
               <div
                 class="stat-card"
@@ -2544,7 +2544,7 @@
                       stroke-linecap="round"
                     ></path>
                   </svg>
-                  Not Paid Today
+                  Not Paid
                 </h3>
                 <div
                   id="notPaidClientsList"


### PR DESCRIPTION
## Purpose
Update the payment status labels to be more concise by changing "Not Paid Today" to simply "Not Paid" as requested by users to make the interface cleaner and reduce text length.

## Code changes
- Changed "Not Paid Today" text to "Not Paid" in two locations within the collectify.html file
- Added new CSS classes `tracker-section-title`, `tracker-title-paid`, and `tracker-title-unpaid` to replace inline styles for better maintainability
- Applied consistent styling with proper spacing, text overflow handling, and color variables for paid/unpaid status indicators

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 31`

🔗 [Edit in Builder.io](https://builder.io/app/projects/00f3650835fd433d91038f82a57269b2/pixel-forge)

👀 [Preview Link](https://00f3650835fd433d91038f82a57269b2-pixel-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>00f3650835fd433d91038f82a57269b2</projectId>-->
<!--<branchName>pixel-forge</branchName>-->