### PR TITLE
Fix sidebar menu text size and spacing on mobile

### DIFF
--- a/collectify.html
+++ b/collectify.html
@@ -1566,6 +1566,12 @@
           padding: 12px 14px;
           font-size: 14px;
         }
+
+        /* Compact sidebar menu on small screens */
+        .sidebar-header { padding: 12px; }
+        .settings-group { margin: 10px; }
+        .sidebar .tab { padding: 12px 14px; font-size: 15px; }
+        .credits-container { padding: 10px 12px; font-size: 12px; }
       }
 
       /* Extra small screens (phones in portrait) */
@@ -1629,6 +1635,12 @@
           font-size: 9px;
           min-width: 45px;
         }
+
+        /* Tighter sidebar for very small screens */
+        .sidebar-header { padding: 10px; }
+        .settings-group { margin: 8px; }
+        .sidebar .tab { padding: 10px 12px; font-size: 14px; }
+        .credits-container { padding: 8px 10px; font-size: 11px; }
       }
 
       /* Landscape orientation optimizations */
@@ -1697,6 +1709,12 @@
         .modal-body {
           max-height: calc(90vh - 120px);
         }
+
+        /* Landscape: conserve vertical space in menu */
+        .sidebar-header { padding: 8px 10px; }
+        .settings-group { margin: 8px; }
+        .sidebar .tab { padding: 8px 10px; font-size: 13px; }
+        .credits-container { padding: 8px 10px; font-size: 11px; }
       }
 
       /* Large screens optimization */


### PR DESCRIPTION
## Purpose
Users reported that the tab text in the sidebar menu was too large, causing the "Abono" text to not be visible properly on mobile devices. This fix addresses the menu text sizing and spacing issues to improve visibility and usability on smaller screens.

## Code changes
- Added responsive CSS rules for sidebar menu components across different screen sizes
- Reduced padding and font sizes for `.sidebar-header`, `.settings-group`, `.sidebar .tab`, and `.credits-container` elements
- Applied different sizing for small screens (480px), extra small screens (360px), and landscape orientation
- Ensured consistent spacing and readability while maintaining the menu's functionality on mobile devices

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 33`

🔗 [Edit in Builder.io](https://builder.io/app/projects/548d4c1b0b384191ad319c650ba812df/curry-garden)

👀 [Preview Link](https://548d4c1b0b384191ad319c650ba812df-curry-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>548d4c1b0b384191ad319c650ba812df</projectId>-->
<!--<branchName>curry-garden</branchName>-->