### PR TITLE
Fix date picker and add stat card hover effects

### DIFF
--- a/collectify.html
+++ b/collectify.html
@@ -8904,6 +8904,12 @@
             );
           };
 
+          // Special case: hidden holiday date input should spotlight the inline calendar
+          if (el.id === "holidayDate") {
+            const cal = document.getElementById("holidayInlineCalendar");
+            if (cal) return cal;
+          }
+
           if (isTiny(el)) {
             if (el.id) {
               const forLabel = document.querySelector(`label[for="${el.id}"]`);

--- a/collectify.html
+++ b/collectify.html
@@ -7829,7 +7829,7 @@
               .reduce((s,p)=>s + (Number(p.amount)||0), 0);
             const amountsHtml = [
               nbAmt>0 ? `<span class=\"cal-amt cal-notebook\">₱${nbAmt.toFixed(0)}</span>` : '',
-              ofAmt>0 ? `<span class=\"cal-amt cal-office\">��${ofAmt.toFixed(0)}</span>` : '',
+              ofAmt>0 ? `<span class=\"cal-amt cal-office\">₱${ofAmt.toFixed(0)}</span>` : '',
               gcAmt>0 ? `<span class=\"cal-amt cal-gcash\">₱${gcAmt.toFixed(0)}</span>` : '',
               adAmt>0 ? `<span class=\"cal-amt cal-adv\" title=\"Advance\">₱${adAmt.toFixed(0)}</span>` : '',
               fullAmt>0 ? `<span class=\"cal-amt cal-full\" title=\"Full Pay\">₱${fullAmt.toFixed(0)}</span>` : ''
@@ -7994,6 +7994,7 @@
         "abonoPaymentDate","absentDate","trackerDate","summaryDate",
         "startDate","fullPaymentDate","planStartDate","holidayDate"
       ];
+      const PREFER_NATIVE_DATE = true;
       let dpTargetId = null;
       let dpYear = null, dpMonth = null, dpSelected = null;
       function pad2(n){ return String(n).padStart(2,"0"); }
@@ -8110,7 +8111,23 @@
           });
         });
       }
+      function revertDateInputs(){
+        const ids = DATE_INPUT_IDS;
+        ids.forEach(id=>{
+          const el = document.getElementById(id);
+          if (!el) return;
+          try { el.type = 'date'; } catch(e) {}
+          el.readOnly = false;
+          el.removeAttribute('inputmode');
+          el.classList.remove('ios-date-input');
+          el.removeAttribute('data-dp-bound');
+        });
+      }
       function attachDatePickers(){
+        if (PREFER_NATIVE_DATE) {
+          revertDateInputs();
+          return;
+        }
         const ids = DATE_INPUT_IDS;
         ids.forEach(id=>{
           const el = document.getElementById(id);
@@ -8128,7 +8145,6 @@
           el.addEventListener('keydown', (e)=>{ if(e.key==='Enter' || e.key===' '){ e.preventDefault(); __open(e);} });
           el.dataset.dpBound = '1';
         });
-        // Global delegation as safety net (covers cases where specific binding failed)
         if (!window.__dpDelegated) {
           const delegate = (e)=>{
             const t = e.target && (e.target.closest ? e.target.closest('input#holidayDate, input.ios-date-input') : null);

--- a/collectify.html
+++ b/collectify.html
@@ -8121,27 +8121,26 @@
           el.readOnly = true;
           el.classList.add('ios-date-input');
           try { el.type = 'text'; } catch(e) {}
-          const __open = (e)=>{ if(e) e.preventDefault(); openDatePicker(id); };
+          const __open = (e)=>{ if(e){ e.preventDefault(); e.stopPropagation(); } openDatePicker(id); };
           el.addEventListener('click', __open);
           el.addEventListener('focus', __open);
+          el.addEventListener('touchstart', __open, { passive: false });
           el.addEventListener('touchend', __open, { passive: false });
+          el.addEventListener('pointerdown', __open);
           el.addEventListener('keydown', (e)=>{ if(e.key==='Enter' || e.key===' '){ e.preventDefault(); __open(e);} });
           el.dataset.dpBound = '1';
         });
         // Global delegation as safety net (covers cases where specific binding failed)
         if (!window.__dpDelegated) {
-          document.addEventListener('click', (e)=>{
-            const t = e.target.closest('input#holidayDate, input.ios-date-input');
-            if (t) { e.preventDefault(); openDatePicker(t.id || 'holidayDate'); }
-          }, true);
-          document.addEventListener('focusin', (e)=>{
-            const t = e.target && (e.target.matches('input#holidayDate, input.ios-date-input') ? e.target : null);
-            if (t) { e.preventDefault?.(); openDatePicker(t.id || 'holidayDate'); }
-          });
-          document.addEventListener('touchend', (e)=>{
-            const t = e.target.closest('input#holidayDate, input.ios-date-input');
-            if (t) { e.preventDefault(); openDatePicker(t.id || 'holidayDate'); }
-          }, { passive: false });
+          const delegate = (e)=>{
+            const t = e.target && (e.target.closest ? e.target.closest('input#holidayDate, input.ios-date-input') : null);
+            if (t) { e.preventDefault?.(); e.stopPropagation?.(); openDatePicker(t.id || 'holidayDate'); }
+          };
+          document.addEventListener('click', delegate, true);
+          document.addEventListener('focusin', delegate);
+          document.addEventListener('touchstart', delegate, { passive: false });
+          document.addEventListener('touchend', delegate, { passive: false });
+          document.addEventListener('pointerdown', delegate, true);
           window.__dpDelegated = true;
         }
       }

--- a/collectify.html
+++ b/collectify.html
@@ -3364,8 +3364,6 @@
                 type="date"
                 id="startDate"
                 onchange="calculateLoanDetails()"
-                onclick="openDatePicker('startDate')"
-                onfocus="openDatePicker('startDate')"
               />
             </div>
           </div>
@@ -7831,7 +7829,7 @@
               .reduce((s,p)=>s + (Number(p.amount)||0), 0);
             const amountsHtml = [
               nbAmt>0 ? `<span class=\"cal-amt cal-notebook\">₱${nbAmt.toFixed(0)}</span>` : '',
-              ofAmt>0 ? `<span class=\"cal-amt cal-office\">₱${ofAmt.toFixed(0)}</span>` : '',
+              ofAmt>0 ? `<span class=\"cal-amt cal-office\">��${ofAmt.toFixed(0)}</span>` : '',
               gcAmt>0 ? `<span class=\"cal-amt cal-gcash\">₱${gcAmt.toFixed(0)}</span>` : '',
               adAmt>0 ? `<span class=\"cal-amt cal-adv\" title=\"Advance\">₱${adAmt.toFixed(0)}</span>` : '',
               fullAmt>0 ? `<span class=\"cal-amt cal-full\" title=\"Full Pay\">₱${fullAmt.toFixed(0)}</span>` : ''

--- a/collectify.html
+++ b/collectify.html
@@ -649,6 +649,19 @@
         transform: translateY(-4px) scale(1.02);
         box-shadow: 0 8px 25px rgba(0, 122, 255, 0.3);
       }
+      /* Emulated hover (for touch/keyboard) */
+      .stat-card.hovered {
+        transform: translateY(-4px) scale(1.02);
+        box-shadow: 0 8px 25px rgba(0, 122, 255, 0.3);
+      }
+      .stat-card:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 3px rgba(0,122,255,0.35), var(--ios-shadow-elevated);
+      }
+      .stat-card.active {
+        transform: translateY(0) scale(0.98);
+        transition-duration: 0.12s;
+      }
 
       .stat-card:nth-child(even) {
         animation-delay: 0.1s;
@@ -3925,6 +3938,8 @@
             }
           });
         }
+        // Enable hover/touch/focus feedback on stat cards
+        enableStatCardHover();
 
         // Recompute default amounts when date changes (Saturday/Monday adjustments)
         const bind = (id, type) => {
@@ -4058,6 +4073,27 @@
           // Ensure Adv list reflects the latest deductions
           updatePaymentHistory("adv");
         }
+      }
+
+      // Hover feedback for stat cards (works on touch + keyboard)
+      function enableStatCardHover(){
+        try {
+          const cards = document.querySelectorAll('#dashboardStats .stat-card, #statsToggleCard.stat-card');
+          cards.forEach((card)=>{
+            card.tabIndex = card.tabIndex || 0;
+            card.addEventListener('mouseenter', ()=>card.classList.add('hovered'));
+            card.addEventListener('mouseleave', ()=>card.classList.remove('hovered'));
+            card.addEventListener('focus', ()=>card.classList.add('hovered'));
+            card.addEventListener('blur', ()=>card.classList.remove('hovered'));
+            card.addEventListener('pointerdown', ()=>card.classList.add('active'));
+            card.addEventListener('pointerup', ()=>card.classList.remove('active'));
+            card.addEventListener('touchstart', ()=>{
+              card.classList.add('hovered');
+              clearTimeout(card.__ht);
+              card.__ht = setTimeout(()=>card.classList.remove('hovered'), 220);
+            }, { passive: true });
+          });
+        } catch (e) {}
       }
 
       // Sidebar functions

--- a/collectify.html
+++ b/collectify.html
@@ -8820,11 +8820,12 @@
           step.needsSidebar ? 450 : 0,
         );
         setTimeout(() => {
-          const el = document.querySelector(step.selector);
-          if (!el) {
+          const raw = document.querySelector(step.selector);
+          if (!raw) {
             onTutorialClick();
             return;
           }
+          const el = resolveSpotlightTarget(raw);
           el.scrollIntoView({
             block: "center",
             inline: "center",
@@ -8841,8 +8842,9 @@
       function refreshSpotlightPosition() {
         if (!tutorial.active) return;
         const step = tutorial.steps[tutorial.index];
-        const el = document.querySelector(step.selector);
-        if (!el) return;
+        const raw = document.querySelector(step.selector);
+        if (!raw) return;
+        const el = resolveSpotlightTarget(raw);
         positionSpotlight(el, step.padding || 4);
         placeInstruction(step.text, el);
       }
@@ -8872,17 +8874,12 @@
         box.style.maxWidth = bw + "px";
         const belowY = r.bottom + 12;
         const aboveY = r.top - 12;
-        // Decide placement
-        let top = belowY;
         let left = r.left;
         if (belowY + 80 > window.innerHeight && aboveY - 60 > 0) {
-          // place above
           box.style.top = r.top - box.offsetHeight - 12 + "px";
         } else {
-          box.style.top =
-            Math.min(window.innerHeight - 16 - box.offsetHeight, belowY) + "px";
+          box.style.top = Math.min(window.innerHeight - 16 - box.offsetHeight, belowY) + "px";
         }
-        // Clamp X within viewport
         const desiredLeft = Math.min(
           Math.max(12, left),
           window.innerWidth - 12 - bw,
@@ -8893,6 +8890,37 @@
       function updateStepCounter() {
         const el = document.getElementById("tutorialStepCounter");
         el.textContent = tutorial.index + 1 + " / " + tutorial.steps.length;
+      }
+
+      // Resolve the best visible element to spotlight (handles hidden inputs like checkboxes/date inputs)
+      function resolveSpotlightTarget(el) {
+        try {
+          const isTiny = (node) => {
+            const cs = window.getComputedStyle(node);
+            return (
+              (node.offsetWidth <= 8 && node.offsetHeight <= 8) ||
+              cs.display === "none" ||
+              cs.visibility === "hidden"
+            );
+          };
+
+          if (isTiny(el)) {
+            if (el.id) {
+              const forLabel = document.querySelector(`label[for="${el.id}"]`);
+              if (forLabel) return forLabel;
+            }
+            const closestLabel = el.closest("label");
+            if (closestLabel) return closestLabel;
+            const container = el.closest(
+              ".release-day, .ios-select-button, button, .form-group, .client-calendar, .calendar-grid, .calendar-header, .tab, .stat-card, .client-list, .header"
+            );
+            if (container) return container;
+            if (el.parentElement) return resolveSpotlightTarget(el.parentElement);
+          }
+          return el;
+        } catch (e) {
+          return el;
+        }
       }
 
       // Escape to exit


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses several UI/UX issues:
- Fix date picker functionality that wasn't opening properly on iOS-style calendars
- Add hover effects to stat cards to enhance user interaction
- Improve tutorial mode spotlight targeting for better user guidance

## Code Changes

**Date Picker Improvements:**
- Added `PREFER_NATIVE_DATE` flag to revert to native date inputs instead of custom iOS-style pickers
- Implemented `revertDateInputs()` function to restore native date input behavior
- Enhanced event delegation for date picker interactions with better event handling
- Removed problematic `onclick` and `onfocus` handlers from start date input

**Stat Card Hover Effects:**
- Added CSS classes for `.hovered`, `.active`, and `:focus-visible` states on stat cards
- Implemented `enableStatCardHover()` function with comprehensive interaction support
- Added support for mouse, touch, keyboard, and pointer events
- Included proper focus management and accessibility features

**Tutorial Mode Enhancements:**
- Added `resolveSpotlightTarget()` function to handle hidden/tiny elements better
- Improved spotlight positioning for date inputs and other UI components
- Enhanced tutorial step targeting with fallback logic for better element detection

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 39`

🔗 [Edit in Builder.io](https://builder.io/app/projects/3a1390c047304e9383357aa1b236133c/zen-lab)

👀 [Preview Link](https://3a1390c047304e9383357aa1b236133c-zen-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3a1390c047304e9383357aa1b236133c</projectId>-->
<!--<branchName>zen-lab</branchName>-->