### PR TITLE
Fix advance payment handling in expected collection

### DIFF
--- a/collectify.html
+++ b/collectify.html
@@ -6973,7 +6973,9 @@
         list.innerHTML = customSummaries
           .map((entry) => {
             const expected = entry.hasFull ? (entry.fullPaid || 0) : entry.dailyAmount;
-            const diff = entry.totalPaid - expected;
+            // Over/Under should ignore ADV created today for future dates
+            const paidForOver = entry.totalPaid - (entry.advForFuture || 0);
+            const diff = paidForOver - expected;
             let statusBadge = "";
             let extraLine = "";
             if (entry.advForFuture && entry.advForFuture > 0) {

--- a/collectify.html
+++ b/collectify.html
@@ -6752,11 +6752,13 @@
             const directPaid = clientPayments.reduce((s, p) => s + (Number(p.amount) || 0), 0);
             const totalPaidForClient = directPaid + advTodayAmt;
 
-            // Expected reflects overpayment: max(expected, paid today)
+            // Expected collection should NOT include advances created today for future dates.
+            // It should include actual same-day payments (including any ADV applied for today) and overpayments.
             const expectedForDate = isClientAbsentOnDate(client.id, selectedDate)
               ? 0
               : expectedAmountForDate(client, selectedDate);
-            totalExpected += Math.max(expectedForDate, totalPaidForClient);
+            const paidForExpected = directPaid; // exclude future-dated ADV created today
+            totalExpected += Math.max(expectedForDate, paidForExpected);
 
             if (totalPaidForClient > 0) {
               // Merge payments with ADV created today as synthetic entries for display badges

--- a/collectify.html
+++ b/collectify.html
@@ -6275,17 +6275,14 @@
           })
           .sort((a,b) => a.clientName.localeCompare(b.clientName));
 
-        // Overpayment per client (exclude Adv from paid sum)
+        // Overpayment per client: ignore ADV created today for future dates (do not treat as overpayment)
         const over = clients.filter(c => c.status !== 'paid').map(c => {
           const expected = isClientAbsentOnDate(c.id, date) ? 0 : expectedAmountForDate(c, date);
           const paidDirect = ['notebook','office','gcash','abono']
             .flatMap(t => payments[t] || [])
             .filter(p => p.clientId === c.id && p.date === date)
             .reduce((s,p) => s + (Number(p.amount)||0), 0);
-          const advExtra = (payments.adv || [])
-            .filter(p => p.clientId === c.id && (p.createdAt || p.date) === date && p.date !== date)
-            .reduce((s,p) => s + (Number(p.amount)||0), 0);
-          const paidSum = paidDirect + advExtra;
+          const paidSum = paidDirect; // exclude ADV created today for future dates
           const diff = paidSum - expected;
           return { clientId: c.id, clientName: c.name, expected, paid: paidSum, overBy: diff };
         }).filter(e => e.overBy > 0.01)


### PR DESCRIPTION
## Purpose

Based on the conversation, the user wanted to fix how advance payments are handled in the collection system. The main goals were:

- Advance payments should not be tagged as overpayments when created today for future dates
- Advance payments should only be counted in expected collection if they are due on the current day
- Overpayments (when a client pays more than expected on the same day) should still be counted in expected collection
- Maintain vanilla HTML structure without advanced modifications

## Code changes

- **Overpayment calculation**: Removed advance payment logic that was incorrectly treating future-dated advances created today as overpayments
- **Expected collection logic**: Modified to exclude advance payments created today for future dates from the expected collection calculation
- **Over/Under calculation**: Updated the difference calculation to ignore advance payments created today for future dates when determining if a client has overpaid or underpaid
- **Comments**: Updated code comments to clarify the new advance payment handling logic

The changes ensure that advance payments are only considered in calculations when they are actually due on the current date, preventing them from being misclassified as overpayments or incorrectly inflating expected collection amounts.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 46`

🔗 [Edit in Builder.io](https://builder.io/app/projects/024ce02cc2834077adbcf6362e933673/cosmos-works)

👀 [Preview Link](https://024ce02cc2834077adbcf6362e933673-cosmos-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>024ce02cc2834077adbcf6362e933673</projectId>-->
<!--<branchName>cosmos-works</branchName>-->