### PR TITLE
Add payment restrictions and full pay 8-day limit

### DIFF
--- a/collectify.html
+++ b/collectify.html
@@ -5210,7 +5210,7 @@
               <div class="client-actions" style="grid-template-columns: repeat(4, 1fr); gap: 6px;">
                 <button class="btn btn-secondary" style="padding: 8px 10px; font-size: 12px;" onclick="openViewClient(${client.id}, this)">View</button>
                 <button class="btn btn-secondary" style="padding: 8px 10px; font-size: 12px;" onclick="editClient(${client.id})">Edit</button>
-                <button class="full-payment-btn" style="padding: 8px 10px; font-size: 12px;" onclick="openFullPaymentModal(${client.id})">Full Pay</button>
+                <button class="full-payment-btn" style="padding: 8px 10px; font-size: 12px;" onclick="openFullPaymentModal(${client.id})" ${Math.ceil(client.remainingBalance / client.dailyAmount - 1e-9) > 8 ? 'disabled title="Allowed when ≤ 8 payment days left"' : ''}>Full Pay</button>
                 <button class="btn btn-danger" style="padding: 8px 10px; font-size: 12px;" onclick="openDeleteModal(${client.id})">Delete</button>
               </div>
             </div>
@@ -5674,6 +5674,13 @@
         const client = clients.find((c) => c.id === clientId);
         if (!client) return;
 
+        // Enforce full pay only when ≤ 8 payment days remain
+        const dleft = getPaymentDaysLeft(client);
+        if (dleft > 8) {
+          showNotification(`Full pay allowed only when ≤ 8 payment days left (currently ${dleft}). Use Adv or plan instead.`, "error");
+          return;
+        }
+
         currentEditingClient = clientId;
         document.getElementById("fullPaymentClientName").textContent =
           client.name;
@@ -5703,6 +5710,13 @@
         // Block if client's start date is in the future
         if (isBeforeClientStart(client, paymentDate)) {
           showNotification(`${client.name} starts on ${parseLocalDate(client.startDate).toLocaleDateString()}. Use Adv tab to set an advance before start date.`, "error");
+          return;
+        }
+
+        // Enforce full pay only when ≤ 8 payment days remain
+        const dleft = getPaymentDaysLeft(client);
+        if (dleft > 8) {
+          showNotification(`Full pay allowed only when ≤ 8 payment days left (currently ${dleft}). Use Adv or plan instead.`, "error");
           return;
         }
 
@@ -6011,6 +6025,15 @@
           const s0 = new Date(s.getFullYear(), s.getMonth(), s.getDate());
           return d0 < s0;
         } catch (e) { return false; }
+      }
+      function getPaymentDaysLeft(client) {
+        try {
+          if (!client) return Infinity;
+          const rb = Number(client.remainingBalance || 0);
+          const daily = Number(client.dailyAmount || 0);
+          if (rb <= 1e-9 || daily <= 1e-9) return 0;
+          return Math.ceil(rb / daily - 1e-9);
+        } catch (e) { return Infinity; }
       }
       function addOrMergePaymentForDate(client, date, amount, preferredType, createdAtOverride) {
         const found = findExistingPaymentAnyType(client.id, date);
@@ -9125,8 +9148,8 @@
           }
         });
 
-        // Extra flavor: one client with daily payments since start and an absence in between
-        (function addConsistentPayer(){
+        // Extra flavor: ensure at least one perfect payer (no absences) and one with absences
+        (function addPerfectPayer(){
           const client = arr[arr.length - 1];
           if (!client) return;
           // Remove any previously created entries for this client
@@ -9135,22 +9158,12 @@
           let remaining = client.totalAmount;
           const types = ['notebook','office','gcash'];
           let ti = 0;
-          // Choose an absence day: 5th working day after start if available
-          let workCount = 0; let chosenAbsent = null;
           const start = parseLocalDate(client.startDate);
           const end = new Date(); end.setDate(end.getDate()-1);
           const endOnly = new Date(end.getFullYear(), end.getMonth(), end.getDate());
           for (let d = new Date(start); d <= endOnly && remaining > 0; d.setDate(d.getDate()+1)) {
             const ds = formatDateLocal(d);
             if (isNonCollectionDay(ds)) continue;
-            workCount++;
-            if (workCount === 5) { chosenAbsent = ds; break; }
-          }
-          const lastDay = endOnly;
-          for (let d = new Date(start); d <= lastDay && remaining > 0; d.setDate(d.getDate()+1)) {
-            const ds = formatDateLocal(d);
-            if (isNonCollectionDay(ds)) continue;
-            if (ds === chosenAbsent) { abs.push({ id: Date.now()+Math.random()*1000|0, clientId: client.id, clientName: client.name, date: ds, reason: 'personal' }); continue; }
             const expected = expectedAmountForDate(client, ds);
             if (expected <= 0) continue;
             const amt = Math.min(expected, remaining);
@@ -9160,6 +9173,39 @@
           }
           client.remainingBalance = Math.max(0, client.totalAmount - Object.values(p).flat().filter(x=>x.clientId===client.id).reduce((s,x)=>s+(Number(x.amount)||0),0));
           client.status = client.remainingBalance <= 1e-6 ? 'paid' : 'active';
+        })();
+        (function addAbsentPatternPayer(){
+          const client = arr[arr.length - 2];
+          if (!client) return;
+          // Clear previous for this client then add absences on two working days
+          Object.keys(p).forEach(t => { p[t] = (p[t]||[]).filter(x => x.clientId !== client.id); });
+          for (let i = abs.length - 1; i >= 0; i--) { if (abs[i].clientId === client.id) abs.splice(i,1); }
+          const start = parseLocalDate(client.startDate);
+          const end = new Date(); end.setDate(end.getDate()-1);
+          const endOnly = new Date(end.getFullYear(), end.getMonth(), end.getDate());
+          let addedAbs = 0;
+          const types = ['notebook','office','gcash'];
+          let ti = 0;
+          for (let d = new Date(start); d <= endOnly; d.setDate(d.getDate()+1)) {
+            const ds = formatDateLocal(d);
+            if (isNonCollectionDay(ds)) continue;
+            if (addedAbs < 2 && Math.random() < 0.15) { abs.push({ id: Date.now()+Math.random()*1000|0, clientId: client.id, clientName: client.name, date: ds, reason: 'personal' }); addedAbs++; continue; }
+            const expected = expectedAmountForDate(client, ds);
+            if (expected <= 0) continue;
+            const amt = Math.min(expected, Math.max(0, client.totalAmount - (Object.values(p).flat().filter(x=>x.clientId===client.id).reduce((s,x)=>s+(Number(x.amount)||0),0))));
+            if (amt <= 0) break;
+            const type = types[ti++ % types.length];
+            p[type].push({ id: Date.now()+Math.random()*100000|0, clientId: client.id, clientName: client.name, amount: amt, date: ds, type: 'daily', paymentType: type });
+          }
+          client.remainingBalance = Math.max(0, client.totalAmount - Object.values(p).flat().filter(x=>x.clientId===client.id).reduce((s,x)=>s+(Number(x.amount)||0),0));
+          client.status = client.remainingBalance <= 1e-6 ? 'paid' : 'active';
+        })();
+
+        // Ensure one active client has exactly 8 payment days left for testing Full Pay rule
+        (function ensureEightDaysLeft(){
+          const candidate = arr.find(c => c.status === 'active' && (c.dailyAmount||0) > 0);
+          if (!candidate) return;
+          candidate.remainingBalance = Math.round((candidate.dailyAmount * 8) * 100) / 100;
         })();
 
         // If today is Sunday, ensure no payments are dated today and no ADV is created today


### PR DESCRIPTION
## Purpose

Based on user requirements, this PR implements payment restrictions to prevent clients from making payments before their start date (except advance payments) and restricts full payments to only when 8 or fewer payment days remain. The demo mode has also been enhanced to include diverse client scenarios including perfect payers, clients with absences, and edge cases for testing the new payment rules.

## Code changes

- **Payment date validation**: Added `isBeforeClientStart()` function to block payments before client start date across all payment methods (plan, quick pay, full pay, and payment editing)
- **Full payment restrictions**: Added `getPaymentDaysLeft()` function and enforced 8-day limit for full payments with disabled button state and validation
- **Advance payment exception**: Allow only advance payments (ADV tab) before client start date
- **Enhanced demo mode**: 
  - Added `addPerfectPayer()` to create clients with consistent daily payments and no absences
  - Added `addAbsentPatternPayer()` to create clients with absence patterns
  - Added `ensureEightDaysLeft()` to create test case for 8-day full payment rule
- **UI improvements**: Full Pay button shows disabled state with tooltip when more than 8 payment days remain
- **Error messaging**: Clear notifications explaining why payments are blocked and suggesting alternatives

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 57`

🔗 [Edit in Builder.io](https://builder.io/app/projects/600236cab34648a4a1d48606e317407e/zen-haven)

👀 [Preview Link](https://600236cab34648a4a1d48606e317407e-zen-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>600236cab34648a4a1d48606e317407e</projectId>-->
<!--<branchName>zen-haven</branchName>-->