### PR TITLE
Reduce sidebar width from 420px to 320px

### DIFF
--- a/collectify.html
+++ b/collectify.html
@@ -359,7 +359,7 @@
         top: 0;
         left: 0;
         height: 100%;
-        width: min(420px, 92vw);
+        width: min(320px, 85vw);
         background: var(--ios-grouped-background);
         z-index: 1201;
         transform: translateX(-100%);


### PR DESCRIPTION
## Purpose
Adjust the sidebar width as it was too wide, ensuring the credits section and tutorial mode spotlighting adapt properly to the new dimensions while maintaining proper alignment and functionality.

## Code changes
- Reduced sidebar width from `min(420px, 92vw)` to `min(320px, 85vw)` in the CSS
- Decreased both the maximum pixel width (420px → 320px) and viewport width percentage (92vw → 85vw)
- Changes made only to `collectify.html` maintaining vanilla HTML structure

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 65`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7f6b505610ca4d63bb729e306a24ba07/aura-haven)

👀 [Preview Link](https://7f6b505610ca4d63bb729e306a24ba07-aura-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7f6b505610ca4d63bb729e306a24ba07</projectId>-->
<!--<branchName>aura-haven</branchName>-->